### PR TITLE
feat [#76]: link and compact buttons

### DIFF
--- a/static/css/src/_m-btn.scss
+++ b/static/css/src/_m-btn.scss
@@ -10,6 +10,8 @@ Markup:
 
 .m-btn--primary - Primary button
 .m-btn--secondary - Secondary button
+.m-btn--link - Link style button
+.m-btn--compact - Compact button
 
 Styleguide: Forms.Buttons
 */
@@ -82,5 +84,13 @@ Styleguide: Forms.Buttons
             background-color: var(--btn-bg--secondary-active);
             color: var(--btn-txt--secondary-active);
         }
+    }
+
+    &--link {
+        text-decoration: none;
+    }
+
+    &--compact {
+        padding: 5px 12px;
     }
 }


### PR DESCRIPTION
Extends m-btn to support,
- links styled as buttons (no underline)
- compact buttons (smaller padding)

Closes #76 