### PR TITLE
feat [#83]: Multiple APIs

### DIFF
--- a/events/api/serializers.py
+++ b/events/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError
 
-from events.models import Timeline, TimelineExhibit
+from events.models import Timeline, TimelineEvent, TimelineExhibit
 from poc.models import UploadedFile
 
 
@@ -115,4 +115,16 @@ class TimelineSerializer(serializers.ModelSerializer):
             "created_by",
             "created_at",
             "updated_at",
+        )
+
+
+class TimelineEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TimelineEvent
+        fields = (
+            "id",
+            "title",
+            "description",
+            "event_date",
+            "place",
         )

--- a/events/api/urls.py
+++ b/events/api/urls.py
@@ -1,8 +1,22 @@
 from django.urls import path
 
-from events.api.views import ListCreateTimelineAPI
+from events.api.views import (
+    ListCreateTimelineAPI,
+    ListTimelineEventsAPI,
+    RetrieveTimelineAPI,
+)
 
 app_name = "events"
 urlpatterns = [
     path("timelines/", ListCreateTimelineAPI.as_view(), name="timelines"),
+    path(
+        "timelines/<int:timeline_id>/",
+        RetrieveTimelineAPI.as_view(),
+        name="timeline_detail",
+    ),
+    path(
+        "timelines/<int:timeline_id>/events/",
+        ListTimelineEventsAPI.as_view(),
+        name="timeline_events",
+    ),
 ]

--- a/events/api/views.py
+++ b/events/api/views.py
@@ -1,12 +1,17 @@
+import uuid
+
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import status
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import ListAPIView, ListCreateAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.serializers import ValidationError
 
-from events.api.serializers import TimelineCreateSerializer, TimelineSerializer
+from events.api.serializers import (
+    TimelineCreateSerializer,
+    TimelineEventSerializer,
+    TimelineSerializer,
+)
 from events.models import Timeline
 from events.tasks import start_timeline_processing
 from poc.models import Case
@@ -16,22 +21,27 @@ class ListCreateTimelineAPI(ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = TimelineCreateSerializer
 
-    def _get_case_id_from_query_params(self):
-        case_id = self.request.query_params.get("case")
-        if case_id is None:
+    def _get_case(self):
+        case_uuid = self.request.query_params.get("case")
+        if case_uuid is None:
             return None
 
         try:
-            return int(case_id)
-        except (TypeError, ValueError):
-            raise ValidationError({"case": "A valid integer is required."})
+            uuid.UUID(case_uuid, version=4)
+        except ValueError:
+            return None
+
+        try:
+            return Case.objects.get(uuid=case_uuid)
+        except Case.DoesNotExist:
+            return Case.objects.none()
 
     def get_queryset(self):
         queryset = Timeline.objects.filter(created_by=self.request.user)
 
-        case_id = self._get_case_id_from_query_params()
-        if case_id is not None:
-            queryset = queryset.filter(case_id=case_id)
+        case = self._get_case()
+        if case:
+            queryset = queryset.filter(case=case)
 
         return queryset
 
@@ -58,3 +68,25 @@ class ListCreateTimelineAPI(ListCreateAPIView):
         return Response(
             TimelineSerializer(timeline).data, status=status.HTTP_201_CREATED
         )
+
+
+class RetrieveTimelineAPI(RetrieveAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = TimelineSerializer
+
+    def get_queryset(self):
+        return Timeline.objects.filter(created_by=self.request.user)
+
+    def get_object(self):
+        timeline_id = self.kwargs.get("timeline_id")
+        return get_object_or_404(self.get_queryset(), id=timeline_id)
+
+
+class ListTimelineEventsAPI(ListAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = TimelineEventSerializer
+
+    def get_queryset(self):
+        timeline_id = self.kwargs.get("timeline_id")
+        timeline = get_object_or_404(Timeline, id=timeline_id)
+        return timeline.events.all()

--- a/events/tests/api/views/test_list_timeline_api.py
+++ b/events/tests/api/views/test_list_timeline_api.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django.urls import reverse
 
 
@@ -38,11 +40,13 @@ def test_with_case_filter(api_client, users, case_factory, timeline_factory):
     timeline_for_case_1 = timeline_factory.create(
         name="Case A Timeline", case=case_1, created_by=users["user1"]
     )
-    timeline_factory.create(name="Case B Timeline", case=case_2, created_by=users["user1"])
+    timeline_factory.create(
+        name="Case B Timeline", case=case_2, created_by=users["user1"]
+    )
 
     response = api_client.get(
         _get_api_url(),
-        data={"case": case_1.id},
+        data={"case": case_1.uuid},
         format="json",
     )
 
@@ -51,19 +55,10 @@ def test_with_case_filter(api_client, users, case_factory, timeline_factory):
     assert response.json()["results"][0]["id"] == timeline_for_case_1.id
 
 
-def test_with_invalid_case_query_param(api_client, users):
-    api_client.force_authenticate(user=users["user1"])
-
-    response = api_client.get(_get_api_url(), data={"case": "invalid"}, format="json")
-
-    assert response.status_code == 400
-    assert response.json() == {"case": "A valid integer is required."}
-
-
 def test_with_non_existent_case_returns_empty_results(api_client, users):
     api_client.force_authenticate(user=users["user1"])
 
-    response = api_client.get(_get_api_url(), data={"case": 999999}, format="json")
+    response = api_client.get(_get_api_url(), data={"case": uuid4()}, format="json")
 
     assert response.status_code == 200
     assert response.json()["count"] == 0

--- a/events/tests/api/views/test_list_timeline_events_api.py
+++ b/events/tests/api/views/test_list_timeline_events_api.py
@@ -1,0 +1,77 @@
+from django.urls import reverse
+from django.utils import timezone
+
+from events.models import TimelineEvent
+
+
+def _get_api_url(timeline_id):
+	return reverse("events_api:timeline_events", kwargs={"timeline_id": timeline_id})
+
+
+def test_with_anonymous_user(api_client, timeline_factory, db):
+	timeline = timeline_factory.create()
+
+	response = api_client.get(_get_api_url(timeline.id))
+
+	assert response.status_code == 403
+
+
+def test_logged_in_user_can_view_any_timeline_events(
+	api_client,
+	users,
+	case_factory,
+	timeline_factory,
+):
+	case = case_factory.create(title="Case A")
+	timeline = timeline_factory.create(case=case, created_by=users["user1"])
+
+	older_event = TimelineEvent.objects.create(
+		timeline=timeline,
+		title="Older Event",
+		description="Older description",
+		event_date=timezone.now(),
+		place="Court Hall 1",
+		data={"source": "test"},
+		source_entity=TimelineEvent.SourceEntity.UPLOADED_FILE,
+		source_entity_id=1,
+	)
+	newer_event = TimelineEvent.objects.create(
+		timeline=timeline,
+		title="Newer Event",
+		description="Newer description",
+		event_date=timezone.now(),
+		place="",
+		data={"source": "test"},
+		source_entity=TimelineEvent.SourceEntity.UPLOADED_FILE,
+		source_entity_id=2,
+	)
+
+	api_client.force_authenticate(user=users["user2"])
+
+	response = api_client.get(_get_api_url(timeline.id), format="json")
+
+	assert response.status_code == 200
+	assert response.json()["count"] == 2
+	assert response.json()["next"] is None
+	assert response.json()["previous"] is None
+
+	first_result = response.json()["results"][0]
+	second_result = response.json()["results"][1]
+
+	assert first_result["id"] == newer_event.id
+	assert first_result["title"] == "Newer Event"
+	assert first_result["description"] == "Newer description"
+	assert first_result["event_date"] is not None
+	assert first_result["place"] == ""
+
+	assert second_result["id"] == older_event.id
+	assert second_result["title"] == "Older Event"
+	assert second_result["place"] == "Court Hall 1"
+
+
+def test_with_non_existent_timeline_returns_404(api_client, users):
+	api_client.force_authenticate(user=users["user1"])
+
+	response = api_client.get(_get_api_url(999999), format="json")
+
+	assert response.status_code == 404

--- a/events/tests/api/views/test_retrieve_timeline_api.py
+++ b/events/tests/api/views/test_retrieve_timeline_api.py
@@ -1,0 +1,52 @@
+from django.urls import reverse
+
+
+def _get_api_url(timeline_id):
+	return reverse("events_api:timeline_detail", kwargs={"timeline_id": timeline_id})
+
+
+def test_with_anonymous_user(api_client, timeline_factory, db):
+	timeline = timeline_factory.create()
+
+	response = api_client.get(_get_api_url(timeline.id))
+
+	assert response.status_code == 403
+
+
+def test_returns_timeline_for_owner(api_client, users, case_factory, timeline_factory):
+	api_client.force_authenticate(user=users["user1"])
+
+	case = case_factory.create(title="Case A")
+	timeline = timeline_factory.create(
+		name="Owner Timeline", case=case, created_by=users["user1"]
+	)
+
+	response = api_client.get(_get_api_url(timeline.id), format="json")
+
+	assert response.status_code == 200
+	assert response.json()["id"] == timeline.id
+	assert response.json()["name"] == "Owner Timeline"
+	assert response.json()["created_by"] == users["user1"].id
+
+
+def test_returns_404_for_timeline_of_another_user(
+	api_client, users, case_factory, timeline_factory
+):
+	api_client.force_authenticate(user=users["user1"])
+
+	case = case_factory.create(title="Case A")
+	timeline = timeline_factory.create(
+		name="Other User Timeline", case=case, created_by=users["user2"]
+	)
+
+	response = api_client.get(_get_api_url(timeline.id), format="json")
+
+	assert response.status_code == 404
+
+
+def test_with_non_existent_timeline_returns_404(api_client, users):
+	api_client.force_authenticate(user=users["user1"])
+
+	response = api_client.get(_get_api_url(999999), format="json")
+
+	assert response.status_code == 404


### PR DESCRIPTION
- updates list-timelines API to make use of the case UUID instead of the case ID.
- adds new retrieve-timeline API
- adds new list-timeline-events API
- adds new TimelineEvent Serializer
- includes unit tests.

Closes #83 