### PR TITLE
feat [#86]: changes to Create Timelines API

### DIFF
--- a/events/api/serializers.py
+++ b/events/api/serializers.py
@@ -6,7 +6,7 @@ from poc.models import UploadedFile
 
 
 class TimelineCreateSerializer(serializers.ModelSerializer):
-    case = serializers.IntegerField(write_only=True)
+    case = serializers.UUIDField(write_only=True)
     exhibits = serializers.ListField(
         child=serializers.IntegerField(min_value=1),
         required=False,

--- a/events/api/views.py
+++ b/events/api/views.py
@@ -49,9 +49,9 @@ class ListCreateTimelineAPI(ListCreateAPIView):
         context = super().get_serializer_context()
 
         if self.request.method == "POST":
-            case_id = self.request.data.get("case")
-            if case_id:
-                case = get_object_or_404(Case, id=case_id)
+            case_uuid = self.request.data.get("case")
+            if case_uuid:
+                case = get_object_or_404(Case, uuid=case_uuid)
                 context["case"] = case
 
         return context

--- a/events/tests/api/views/test_create_timeline_api.py
+++ b/events/tests/api/views/test_create_timeline_api.py
@@ -44,7 +44,7 @@ def test_with_duplicate_name_for_case(
         _get_api_url(),
         data={
             "name": "Timeline Alpha",
-            "case": case.id,
+            "case": case.uuid,
             "exhibits": [exhibit.id],
         },
         format="json",
@@ -63,7 +63,7 @@ def test_without_exhibits_param_and_no_case_exhibits(api_client, users, case_fac
         _get_api_url(),
         data={
             "name": "Timeline Alpha",
-            "case": case.id,
+            "case": case.uuid,
         },
         format="json",
     )
@@ -84,7 +84,7 @@ def test_with_empty_exhibits_list(api_client, users, case_factory):
         _get_api_url(),
         data={
             "name": "Timeline Alpha",
-            "case": case.id,
+            "case": case.uuid,
             "exhibits": [],
         },
         format="json",
@@ -131,7 +131,7 @@ def test_happy_path_with_specific_exhibits(
             _get_api_url(),
             data={
                 "name": "Timeline Alpha",
-                "case": case.id,
+                "case": case.uuid,
                 "exhibits": [exhibit_1.id, exhibit_2.id],
             },
             format="json",
@@ -181,7 +181,7 @@ def test_happy_path_without_exhibits_uses_all_case_exhibits(
         _get_api_url(),
         data={
             "name": "Timeline Alpha",
-            "case": case.id,
+            "case": case.uuid,
         },
         format="json",
     )


### PR DESCRIPTION
- case parameter now accepts UUID instead of the ID (PK)
- includes updated unit tests

Closes #86 